### PR TITLE
Add (very ugly) authn support

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "i18next-http-backend": "^1.3.2",
         "i18next-resources-to-backend": "^1.0.0",
         "iso-639-1": "^2.1.13",
+        "js-cookie": "^3.0.1",
         "just-compose": "^2.1.0",
         "lodash-es": "^4.17.21",
         "memoize-one": "^5.1.1",

--- a/public/auth-dev.html
+++ b/public/auth-dev.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+        name="description"
+        content="Web site created using create-react-app"
+    />
+    <title>React App</title>
+</head>
+<body>
+<!-- TODO(mlazowik): load this from the installed package instead of the CDN -->
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
+<script>
+    function parseJwt (token) {
+        const base64Url = token.split('.')[1];
+        const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+        const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+        }).join(''));
+
+        return JSON.parse(jsonPayload);
+    }
+
+    function handleCredentialResponse(response) {
+        const jwt = parseJwt(response.credential);
+        const googleTokenExpirationUnixTimestamp = jwt.exp;
+        const MS_PER_MINUTE = 60000;
+        const cookieExpirationDate = new Date(googleTokenExpirationUnixTimestamp * 1000 - 2 * MS_PER_MINUTE);
+        const expirationWarningDate = new Date(googleTokenExpirationUnixTimestamp * 1000 - 5 * MS_PER_MINUTE);
+
+        console.log(parseJwt(response.credential));
+        console.log(parseJwt(response.credential).exp);
+
+        Cookies.set('jwt', response.credential, {
+            expires: cookieExpirationDate,
+            sameSite: 'strict',
+            secure: true,
+        });
+
+        Cookies.set('jwt_does_not_expire_soon', 'true', {
+            expires: expirationWarningDate,
+            sameSite: 'strict',
+            secure: true,
+        });
+
+        window.location.replace('/');
+    }
+</script>
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+<div id="g_id_onload"
+     data-client_id="1089860096133-2iffpbk6su292ec43tjo26t4rb3gjg5i.apps.googleusercontent.com"
+     data-context="signin"
+     data-auto_prompt="false"
+     data-callback="handleCredentialResponse">
+</div>
+<div class="g_id_signin" data-type="standard"></div>
+</body>
+</html>

--- a/public/auth-dev.html
+++ b/public/auth-dev.html
@@ -31,9 +31,6 @@
         const cookieExpirationDate = new Date(googleTokenExpirationUnixTimestamp * 1000 - 2 * MS_PER_MINUTE);
         const expirationWarningDate = new Date(googleTokenExpirationUnixTimestamp * 1000 - 5 * MS_PER_MINUTE);
 
-        console.log(parseJwt(response.credential));
-        console.log(parseJwt(response.credential).exp);
-
         Cookies.set('jwt', response.credential, {
             expires: cookieExpirationDate,
             sameSite: 'strict',

--- a/public/auth-prod.html
+++ b/public/auth-prod.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <meta
+        name="description"
+        content="Web site created using create-react-app"
+    />
+    <title>React App</title>
+</head>
+<body>
+<!-- TODO(mlazowik): load this from the installed package instead of the CDN -->
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
+<script>
+    function parseJwt (token) {
+        const base64Url = token.split('.')[1];
+        const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+        const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+        }).join(''));
+
+        return JSON.parse(jsonPayload);
+    }
+
+    function handleCredentialResponse(response) {
+        const jwt = parseJwt(response.credential);
+        const googleTokenExpirationUnixTimestamp = jwt.exp;
+        const MS_PER_MINUTE = 60000;
+        const cookieExpirationDate = new Date(googleTokenExpirationUnixTimestamp * 1000 - 2 * MS_PER_MINUTE);
+        const expirationWarningDate = new Date(googleTokenExpirationUnixTimestamp * 1000 - 5 * MS_PER_MINUTE);
+
+        console.log(parseJwt(response.credential));
+        console.log(parseJwt(response.credential).exp);
+
+        Cookies.set('jwt', response.credential, {
+            expires: cookieExpirationDate,
+            sameSite: 'strict',
+            secure: true,
+        });
+
+        Cookies.set('jwt_does_not_expire_soon', 'true', {
+            expires: expirationWarningDate,
+            sameSite: 'strict',
+            secure: true,
+        });
+
+        window.location.replace('/');
+    }
+</script>
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+<div id="g_id_onload"
+     data-client_id="510426673347-djors3udlj4vkcgf9haio8156bro1981.apps.googleusercontent.com"
+     data-context="signin"
+     data-auto_prompt="false"
+     data-callback="handleCredentialResponse">
+</div>
+<div class="g_id_signin" data-type="standard"></div>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,19 @@
     <title>React App</title>
 </head>
 <body>
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.1/dist/js.cookie.min.js"></script>
+<script>
+    console.log(window.location);
+    if (Cookies.get('jwt_does_not_expire_soon') !== 'true') {
+        <!-- TODO(mlazowik): pass a redir path to go back from the user was redirected -->
+        if ('%REACT_APP_ENV%' === 'dev') {
+            window.location.replace('/auth-dev.html');
+        } else {
+            window.location.replace('/auth-prod.html');
+        }
+        //window.location.replace('/auth-dev.html');
+    }
+</script>
 <noscript>You need to enable JavaScript to run this app.</noscript>
 <div id="root"></div>
 <!--

--- a/src/hooks/api/accommodationHooks.jsx
+++ b/src/hooks/api/accommodationHooks.jsx
@@ -1,12 +1,12 @@
 import useAxios from "axios-hooks";
-import { getErrorsFromApi, getPath } from "services/Api/utils";
+import { getAuthenticationHeaders, getErrorsFromApi, getPath } from "services/Api/utils";
 import { Paths } from "services/Api/constants";
 import { classToPlain, plainToClass } from "serializers/Serializer";
 import Accommodation from "models/Accommodation";
 
 const useCreateAccommodation = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "POST" },
+        { method: "POST", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -52,7 +52,7 @@ const useCreateAccommodation = () => {
 
 const useGetAccommodation = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "GET" },
+        { method: "GET", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -92,7 +92,7 @@ const useGetAccommodation = () => {
 
 const useUpdateAccommodation = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "PUT" },
+        { method: "PUT", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -140,7 +140,7 @@ const useUpdateAccommodation = () => {
 
 const useAddGuestToAccommodation = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "POST" },
+        { method: "POST", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 

--- a/src/hooks/api/accommodationsHooks.jsx
+++ b/src/hooks/api/accommodationsHooks.jsx
@@ -1,12 +1,12 @@
 import useAxios from "axios-hooks";
-import { getErrorsFromApi, getPath } from "services/Api/utils";
+import { getAuthenticationHeaders, getErrorsFromApi, getPath } from "services/Api/utils";
 import { Paths } from "services/Api/constants";
 import { plainToClass } from "serializers/Serializer";
 import Accommodation from "models/Accommodation";
 
 const useGetAccommodations = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "GET" },
+        { method: "GET", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 

--- a/src/hooks/api/guestHooks.jsx
+++ b/src/hooks/api/guestHooks.jsx
@@ -1,12 +1,12 @@
 import useAxios from "axios-hooks";
-import { getErrorsFromApi, getPath } from "services/Api/utils";
+import { getAuthenticationHeaders, getErrorsFromApi, getPath } from "services/Api/utils";
 import { Paths } from "services/Api/constants";
 import { classToPlain, plainToClass } from "serializers/Serializer";
 import Guest from "models/Guest";
 
 const useGetGuest = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "GET" },
+        { method: "GET", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -44,7 +44,7 @@ const useGetGuest = () => {
 
 const useUpdateGuest = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "PUT" },
+        { method: "PUT", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -90,7 +90,7 @@ const useUpdateGuest = () => {
 
 const useCreateGuest = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "POST" },
+        { method: "POST", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 

--- a/src/hooks/api/guestsHooks.jsx
+++ b/src/hooks/api/guestsHooks.jsx
@@ -1,12 +1,12 @@
 import useAxios from "axios-hooks";
-import { getErrorsFromApi, getPath } from "services/Api/utils";
+import { getAuthenticationHeaders, getErrorsFromApi, getPath } from "services/Api/utils";
 import { Paths } from "services/Api/constants";
 import { plainToClass } from "serializers/Serializer";
 import Guest from "models/Guest";
 
 const useGetGuests = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "GET" },
+        { method: "GET", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 

--- a/src/hooks/api/hostHooks.jsx
+++ b/src/hooks/api/hostHooks.jsx
@@ -1,12 +1,12 @@
 import useAxios from "axios-hooks";
-import { getErrorsFromApi, getPath } from "services/Api/utils";
+import { getAuthenticationHeaders, getErrorsFromApi, getPath } from "services/Api/utils";
 import { Paths } from "services/Api/constants";
 import { classToPlain, plainToClass } from "serializers/Serializer";
 import Host from "models/Host";
 
 const useCreateHost = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "POST" },
+        { method: "POST", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -49,7 +49,7 @@ const useCreateHost = () => {
 
 const useGetHost = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "GET" },
+        { method: "GET", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 
@@ -84,7 +84,7 @@ const useGetHost = () => {
 
 const useUpdateHost = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "PUT" },
+        { method: "PUT", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 

--- a/src/hooks/api/hostsHooks.jsx
+++ b/src/hooks/api/hostsHooks.jsx
@@ -1,12 +1,12 @@
 import useAxios from "axios-hooks";
-import { getErrorsFromApi, getPath } from "services/Api/utils";
+import {getAuthenticationHeaders, getErrorsFromApi, getPath} from "services/Api/utils";
 import { Paths } from "services/Api/constants";
 import { plainToClass } from "serializers/Serializer";
 import Host from "models/Host";
 
 const useGetHosts = () => {
     const [{ data, loading, error }, fetch] = useAxios(
-        { method: "GET" },
+        { method: "GET", headers: getAuthenticationHeaders() },
         { manual: true, autoCancel: false }
     );
 

--- a/src/services/Api/utils.js
+++ b/src/services/Api/utils.js
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie';
 import HttpStatus from "http-status-codes";
 import get from "lodash-es/get";
 import { compile } from "path-to-regexp";
@@ -69,3 +70,11 @@ export const getPath = (url, options) => {
     const toPath = compile(url, { encode: encodeURIComponent });
     return toPath(options);
 };
+
+// TODO(mlazowik): create a hook that wraps `useAxios` and adds the auth header.
+export const getAuthenticationHeaders = () => {
+    // TODO(mlazowik): handle the case where it's expired
+    return {
+        'Authorization': `Bearer ${Cookies.get('jwt')}`
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7204,6 +7204,11 @@ jest@24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
1. Raw js code in index.html checks if the auth is expired/will expire
   soon
2. If yes, it redirects to dev/prod auth html page
3. That page loads Google's auth library and the sign in button
4. On successful login (no errors handling yet) the jwt is saved in a
   cookie
5. When sending API requests the jwt from the cookie is read and passed
   in the authorization header

Note there is no handling of the case where the auth token expires
mid-session. Google tokens are valid for 1h so it is definitely going to
happen to users. For now we can tell them to do a full reload of the
browser tab in that case.