### PR TITLE
Add Cypress tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ same way as everybody else.
 ```shell
 git config --local core.autocrlf input
 ```
-The LF is our line ending of choice. Be sure to set 
+The LF is our line ending of choice. Be sure to set
 
 1. Go **Settings…** » **Editor** » **Code Style** and select `Unix and macOS (\n)` as Line separator.
 
@@ -30,7 +30,7 @@ to install project dependencies.
 3. Choose Prettier plugin path from the dropdown.
 4. Set "Run for files" to `{**/*,*}.{js,ts,jsx,tsx,json,css,scss,sass}`
 5. Check both **On Reformat Code action** and **On Save** checkboxes.
-6. Go **Settings…** » **Languages & Frameworks** » **JavaScript** » **Code Quality Tools** » **ESLint** » and select *Automatic ESLint configuration*. 
+6. Go **Settings…** » **Languages & Frameworks** » **JavaScript** » **Code Quality Tools** » **ESLint** » and select *Automatic ESLint configuration*.
 
 ### Install Webstorm plugins
 
@@ -44,7 +44,7 @@ npm config set "@fortawesome:registry" https://npm.fontawesome.com/
 npm config set "//npm.fontawesome.com/:_authToken" ????????-????-????-????-????????????
 ```
 
-Ask for **_authToken** value on *#frontend* channel of the project's Discord. 
+Ask for **_authToken** value on *#frontend* channel of the project's Discord.
 
 ## Development
 
@@ -86,3 +86,25 @@ Create `.env.production.local` and set values as suggested by backend team. Then
 ```shell
 yarn build
 ```
+## Cypress Sanity Tests
+
+UI sanity tests are located in `cypress/integration` directory
+
+### How to run
+
+Build the app first and then run the tests:
+```shell
+yarn run cypress
+```
+
+### Skipping failing tests
+
+Most of the selectors are text-based and are prone to failure on UI change.
+If a tests fails due to change in the UI / selectors you can skip it by modifying the `*.spec.js` file in `cypress/integration` and adding `skip` attribute to `it()`.
+```javascript
+it.skip('Failing test', () => {})
+```
+
+### Run tests locally
+In order to run the tests locally you will need to add values for `REACT_APP_GOOGLE_CLIENTID`, `REACT_APP_GOOGLE_CLIENT_SECRET` and `GOOGLE_REFRESH_TOKEN` in your local `.env` file.
+Ask for them on `#frontend` in Slack or [obtain them yourself](https://docs.cypress.io/guides/testing-strategies/google-authentication#Using-the-Google-OAuth-2-0-Playground-to-Create-Testing-Credentials)

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,6 @@
+{
+    "defaultCommandTimeout": 15000,
+    "baseUrl": "http://localhost:3000/",
+    "videoUploadOnPasses": false,
+    "env": {}
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/accommodations.spec.js
+++ b/cypress/integration/accommodations.spec.js
@@ -1,0 +1,23 @@
+import accommodations from "../pages/accommodations-page";
+
+describe("Validate accommodations page", () => {
+    beforeEach(() => {
+        window.localStorage.setItem("kokon-settings", '{"isEnableMocks": true}');
+        cy.loginByGoogleApi();
+        cy.visit("/accommodations");
+    });
+
+    it("Accommodations page elements are rendered", () => {
+        accommodations.cardsContainer.should("be.visible");
+        accommodations.cardsHeader.should("contain.text", "Accommodation Units");
+        accommodations.refreshButton.should("be.visible");
+        accommodations.addButton.should("be.visible");
+        accommodations.table.should("be.visible");
+        accommodations.firstTableRow.should("be.visible");
+    });
+
+    it("Add accommodation button works", () => {
+        accommodations.addButton.click();
+        cy.url().should("contain", "/accommodations/create");
+    });
+});

--- a/cypress/integration/createHost.spec.js
+++ b/cypress/integration/createHost.spec.js
@@ -1,0 +1,22 @@
+import createHost from "../pages/create-host-page";
+import hosts from "../pages/hosts-page";
+
+describe("Create a Hosts", () => {
+    beforeEach(() => {
+        window.localStorage.setItem("kokon-settings", '{"isEnableMocks": true}');
+        cy.loginByGoogleApi();
+        cy.visit("/hosts/create");
+    });
+    it("Create host form is rendered", () => {
+        createHost.cardsContainer.should("be.visible");
+        createHost.cardsHeader.should("contain.text", "Create a new Host");
+        createHost.submitButton.should("be.visible");
+    });
+
+    it("Add a new host", () => {
+        createHost.fillHostForm();
+        createHost.submitButton.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}hosts`);
+        hosts.validateNewHostAdded();
+    });
+});

--- a/cypress/integration/guests.spec.js
+++ b/cypress/integration/guests.spec.js
@@ -1,0 +1,22 @@
+import guests from "../pages/guests-page";
+
+describe("Validate guests page", () => {
+    beforeEach(() => {
+        window.localStorage.setItem("kokon-settings", '{"isEnableMocks": true}');
+        cy.loginByGoogleApi();
+        cy.visit("/guests");
+    });
+    it("Guests page elements are rendered", () => {
+        guests.cardsContainer.should("be.visible");
+        guests.cardsHeader.should("contain.text", "Guests");
+        guests.refreshButton.should("be.visible");
+        guests.addButton.should("be.visible");
+        guests.table.should("be.visible");
+        guests.firstTableRow.should("be.visible");
+    });
+
+    it("Add guest button works", () => {
+        guests.addButton.click();
+        cy.url().should("contain", "/guests/create");
+    });
+});

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -1,0 +1,37 @@
+import home from "../pages/home";
+
+describe("Validate home page", () => {
+    beforeEach(() => {
+        cy.loginByGoogleApi();
+        cy.visit("/");
+    });
+
+    it("Home page elements are rendered", () => {
+        home.cardsContainer.should("be.visible");
+        home.cardsHeader.should("contain.text", "What do you want to do?");
+
+        home.accommodationsCardTitle.should("contain.text", "Accommodation Units management");
+        home.accommodationsButton.should("be.visible");
+
+        home.guestsCardTitle.should("contain.text", "Guests management");
+        home.guestsButton.should("be.visible");
+
+        home.hostsCardTitle.should("contain.text", "Hosts management");
+        home.hostsButton.should("be.visible");
+    });
+
+    it("Navigate to Accommodations", () => {
+        home.accommodationsButton.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}accommodations`);
+    });
+
+    it("Navigate to Guests", () => {
+        home.guestsButton.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}guests`);
+    });
+
+    it("Navigate to Hosts", () => {
+        home.hostsButton.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}hosts`);
+    });
+});

--- a/cypress/integration/hosts.spec.js
+++ b/cypress/integration/hosts.spec.js
@@ -1,0 +1,22 @@
+import hosts from "../pages/hosts-page";
+
+describe("Validate hosts page", () => {
+    beforeEach(() => {
+        window.localStorage.setItem("kokon-settings", '{"isEnableMocks": true}');
+        cy.loginByGoogleApi();
+        cy.visit("/hosts");
+    });
+    it("Hosts page elements are rendered", () => {
+        hosts.cardsContainer.should("be.visible");
+        hosts.cardsHeader.should("contain.text", "Hosts");
+        hosts.refreshButton.should("be.visible");
+        hosts.addButton.should("be.visible");
+        hosts.table.should("be.visible");
+        hosts.firstTableRow.should("be.visible");
+    });
+
+    it("Add host button works", () => {
+        hosts.addButton.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}hosts/create`);
+    });
+});

--- a/cypress/integration/navigationBar.spec.js
+++ b/cypress/integration/navigationBar.spec.js
@@ -1,0 +1,30 @@
+import navigationBar from "../pages/navigation-bar";
+
+describe("Use navigation bar", () => {
+    beforeEach(() => {
+        cy.loginByGoogleApi();
+    });
+
+    it("Open accommodation from navbar", () => {
+        cy.visit("/");
+        navigationBar.accommodation.click();
+    });
+
+    it("Open guests from navbar", () => {
+        cy.visit("/");
+        navigationBar.guests.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}guests`);
+    });
+
+    it("Open hosts from navbar", () => {
+        cy.visit("/");
+        navigationBar.hosts.click();
+        cy.url().should("eq", `${Cypress.config().baseUrl}hosts`);
+    });
+
+    it("Open home dashboard from navbar", () => {
+        cy.visit("/accommodation");
+        navigationBar.home.click();
+        cy.url().should("eq", Cypress.config().baseUrl);
+    });
+});

--- a/cypress/pages/accommodations-page.js
+++ b/cypress/pages/accommodations-page.js
@@ -1,0 +1,5 @@
+import DataViewPage from "./page-templates/data-view.page";
+
+class AccommodationsPage extends DataViewPage {}
+
+export default new AccommodationsPage();

--- a/cypress/pages/create-host-page.js
+++ b/cypress/pages/create-host-page.js
@@ -1,0 +1,40 @@
+import BasePage from "./page-templates/base-page";
+import hosts from "./hosts-page";
+
+class CreateHostPage extends BasePage {
+    get submitButton() {
+        return cy.get('button[type="submit"]');
+    }
+    get statusField() {
+        return cy.get("#status");
+    }
+
+    get fullNameField() {
+        return cy.get("#fullName");
+    }
+
+    get emailField() {
+        return cy.get("#email");
+    }
+
+    get phoneNumberField() {
+        return cy.get("#phoneNumber");
+    }
+
+    get commentsField() {
+        return cy.get("#comments");
+    }
+
+    fillHostForm() {
+        this.fullNameField.type("Tester Testerski");
+        this.fullNameField.should("have.value", "Tester Testerski");
+        this.emailField.type("tester@testerski.pl");
+        this.emailField.should("have.value", "tester@testerski.pl");
+        this.phoneNumberField.type("+48101202303");
+        this.phoneNumberField.should("have.value", "+48101202303");
+        this.commentsField.type("It's a test");
+        this.commentsField.should("have.value", "It's a test");
+    }
+}
+
+export default new CreateHostPage();

--- a/cypress/pages/guests-page.js
+++ b/cypress/pages/guests-page.js
@@ -1,0 +1,5 @@
+import DataViewPage from "./page-templates/data-view.page";
+
+class GuestsPage extends DataViewPage {}
+
+export default new GuestsPage();

--- a/cypress/pages/home.js
+++ b/cypress/pages/home.js
@@ -1,0 +1,41 @@
+import BasePage from "./page-templates/base-page";
+
+class HomePage extends BasePage {
+    get accommodationsCardTitle() {
+        return cy.get(".bg-accommodations").find("h5");
+    }
+
+    get accommodationsCardDesc() {
+        return cy.get(".bg-accomodations").find(".card-text");
+    }
+
+    get accommodationsButton() {
+        return cy.get(".btn-accommodations");
+    }
+
+    get guestsCardTitle() {
+        return cy.get(".bg-guests").find("h5");
+    }
+
+    get guestsCardDesc() {
+        return cy.get(".bg-guests").find(".card-text");
+    }
+
+    get guestsButton() {
+        return cy.get(".btn-guests");
+    }
+
+    get hostsCardTitle() {
+        return cy.get(".bg-hosts").find("h5");
+    }
+
+    get accommodationsCardDesc() {
+        return cy.get(".bg-hosts").find(".card-text");
+    }
+
+    get hostsButton() {
+        return cy.get(".btn-hosts");
+    }
+}
+
+export default new HomePage();

--- a/cypress/pages/hosts-page.js
+++ b/cypress/pages/hosts-page.js
@@ -1,0 +1,13 @@
+import DataViewPage from "./page-templates/data-view.page";
+
+class HostsPage extends DataViewPage {
+    validateNewHostAdded() {
+        this.toastMessage.should("be.visible");
+        this.toastMessage.should("contain.text", "Action successful");
+        this.firstTableRow.should("contain.text", "Tester Testerski");
+        this.firstTableRow.should("contain.text", "tester@testerski.pl");
+        this.firstTableRow.should("contain.text", "+48101202303");
+        this.firstTableRow.should("contain.text", "It's a test");
+    }
+}
+export default new HostsPage();

--- a/cypress/pages/navigation-bar.js
+++ b/cypress/pages/navigation-bar.js
@@ -1,0 +1,19 @@
+class NavigationBar {
+    get home() {
+        return cy.get('li.nav-item').contains('Dashboard')
+    }
+
+    get accommodation() {
+        return cy.get('li.nav-item').contains('Accommodation')
+    }
+
+    get guests() {
+        return cy.get('li.nav-item').contains('Guests')
+    }
+
+    get hosts() {
+        return cy.get('li.nav-item').contains('Hosts')
+    }
+}
+
+export default new NavigationBar()

--- a/cypress/pages/page-templates/base-page.js
+++ b/cypress/pages/page-templates/base-page.js
@@ -1,0 +1,11 @@
+class BasePage {
+    get cardsHeader() {
+        return cy.get("div.card-header").find("h4");
+    }
+
+    get cardsContainer() {
+        return cy.get(".card-body");
+    }
+}
+
+export default BasePage;

--- a/cypress/pages/page-templates/data-view.page.js
+++ b/cypress/pages/page-templates/data-view.page.js
@@ -1,0 +1,24 @@
+import BasePage from "./base-page";
+
+export class DataViewPage extends BasePage {
+    get refreshButton() {
+        return cy.get("button").contains("Refresh data");
+    }
+
+    get addButton() {
+        return cy.get("button").contains(/^Add( a)? new/);
+    }
+    get table() {
+        return cy.get("table.table");
+    }
+
+    get firstTableRow() {
+        return cy.get("tbody tr:first");
+    }
+
+    get toastMessage() {
+        return cy.get(".toast-content");
+    }
+}
+
+export default DataViewPage;

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,32 @@
+const dotenv = require("dotenv");
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+// eslint-disable-next-line no-unused-vars
+dotenv.config()
+
+
+module.exports = (on, config) => {
+    // `on` is used to hook into various events Cypress emits
+    // `config` is the resolved Cypress config
+    config.env.googleRefreshToken = process.env.GOOGLE_REFRESH_TOKEN
+    config.env.googleClientId = process.env.REACT_APP_GOOGLE_CLIENTID
+    config.env.googleClientSecret = process.env.REACT_APP_GOOGLE_CLIENT_SECRET
+
+    return config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,42 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add('login', (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+Cypress.Commands.add("loginByGoogleApi", () => {
+    cy.log("Logging in to Google");
+    cy.request({
+        method: "POST",
+        url: "https://www.googleapis.com/oauth2/v4/token",
+        body: {
+            grant_type: "refresh_token",
+            client_id: Cypress.env("googleClientId"),
+            client_secret: Cypress.env("googleClientSecret"),
+            refresh_token: Cypress.env("googleRefreshToken"),
+        },
+    }).then(({ body }) => {
+        const { id_token } = body;
+        window.localStorage.setItem("kokon-auth-token", id_token);
+    });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
         },
         {
             "name": "Miron Markowski"
+        },
+        {
+            "name": "Łukasz Bartkowiak",
+            "email": "lubartkowiak@gmail.com"
         }
     ],
     "version": "0.1.2",
@@ -67,6 +71,9 @@
         "camelcase-keys": "7.0.2",
         "chance": "1.1.8",
         "classnames": "2.3.1",
+        "cypress": "^9.5.2",
+        "cypress-dotenv": "^2.0.0",
+        "dotenv": "^16.0.0",
         "formik": "2.2.9",
         "formik-yup": "^0.0.5",
         "http-status-codes": "2.2.0",
@@ -108,7 +115,8 @@
         "start": "react-app-rewired start",
         "build": "react-app-rewired build",
         "test": "react-app-rewired test",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "cypress": "cypress run"
     },
     "browserslist": {
         "production": [


### PR DESCRIPTION
FR-168 Add Cypress tests

Important! In order for tests to work you need to configure google auth tokens in .env
Run tests with `yarn/npm run cypress` after building the app and configuring tokens (instructions in the readme)

Task scope:
1. Add /cypress and cypress.json
2. Add tests to /cypress/integration
3. Write Page Objects and their common parent classes in /cypress/integration/pages & /cypress/integration/page-templates
4. Modify content of package.json
5. Add readme for UI tests




